### PR TITLE
fix timeproperty does not exist behaviour

### DIFF
--- a/src/main/java/org/fiware/mintaka/persistence/EntityRepository.java
+++ b/src/main/java/org/fiware/mintaka/persistence/EntityRepository.java
@@ -101,4 +101,12 @@ public interface EntityRepository {
 	 * @return the list of timestamps
 	 */
 	List<Instant> getCreatedAtForAttribute(String attributeId, String entityId, boolean isSubAttribute);
+
+	/**
+	 * Return an entity in case there are any instances of the entity in timescale db.
+	 *
+	 * @param entityId id of the entity to check
+	 * @return NgsiEntity if one exists
+	 */
+	Optional<NgsiEntity> getEntityIfExists(String entityId);
 }

--- a/src/main/java/org/fiware/mintaka/persistence/TimescaleBackedEntityRepository.java
+++ b/src/main/java/org/fiware/mintaka/persistence/TimescaleBackedEntityRepository.java
@@ -340,6 +340,14 @@ public class TimescaleBackedEntityRepository implements EntityRepository {
 		return instantTypedQuery.getResultList().stream().map(localDateTime -> localDateTime.toInstant(ZoneOffset.UTC)).collect(Collectors.toList());
 	}
 
+	@Override
+	public Optional<NgsiEntity> getEntityIfExists(String entityId) {
+		TypedQuery<NgsiEntity> getNgsiEntitiesQuery = entityManager.createQuery(
+				"Select entity from NgsiEntity entity where id=:entityId", NgsiEntity.class);
+		getNgsiEntitiesQuery.setParameter("entityId", entityId);
+		return getNgsiEntitiesQuery.getResultList().stream().findFirst();
+	}
+
 	/**
 	 * Create the sql selection criteria, based on the QueryTerm, while including all additional parameters. Geoqueries are handle as a seperate
 	 * query term.

--- a/src/main/java/org/fiware/mintaka/rest/TemporalApiController.java
+++ b/src/main/java/org/fiware/mintaka/rest/TemporalApiController.java
@@ -22,6 +22,7 @@ import org.fiware.mintaka.domain.query.temporal.TimeStampType;
 import org.fiware.mintaka.exception.InvalidTimeRelationException;
 import org.fiware.mintaka.exception.PersistenceRetrievalException;
 import org.fiware.mintaka.persistence.LimitableResult;
+import org.fiware.mintaka.persistence.NgsiEntity;
 import org.fiware.mintaka.service.EntityTemporalService;
 import org.fiware.ngsi.api.TemporalRetrievalApi;
 import org.fiware.ngsi.model.EntityInfoVO;
@@ -252,6 +253,10 @@ public class TemporalApiController implements TemporalRetrievalApi {
 						isTemporalValuesOptionSet(options));
 
 		if (optionalLimitableResult.isEmpty()) {
+			Optional<EntityTemporalVO> optionalEntity = entityTemporalService.getNgsiEntity(entityId.toString());
+			if (optionalEntity.isPresent()) {
+				return HttpResponse.ok(addContextToEntityTemporalVO(optionalEntity.get(), contextUrls));
+			}
 			return HttpResponse.notFound();
 		}
 

--- a/src/main/java/org/fiware/mintaka/service/EntityTemporalService.java
+++ b/src/main/java/org/fiware/mintaka/service/EntityTemporalService.java
@@ -299,6 +299,10 @@ public class EntityTemporalService {
 		return getNgsiEntitiesWithTimerel(entityId, timeQuery, attrs, sysAttrs, temporalRepresentation, entityRepository.getLimit(1, attrs.size(), lastN), lastN != null);
 	}
 
+	@ReadOnly
+	public Optional<EntityTemporalVO> getNgsiEntity(String entityId) {
+		return entityRepository.getEntityIfExists(entityId).map(ngsiEntity -> new EntityTemporalVO().setId(URI.create(ngsiEntity.getId())).setType(ngsiEntity.getType()));
+	}
 
 	private void addSubAttributesToAttributeInstance(String entityId, Map.Entry<String, Object> propertyEntry, List<String> instancesWithSubattributes, boolean createdAt, boolean modifiedAt, int limit, boolean backwards) {
 		if (propertyEntry.getValue() == null) {

--- a/src/test/java/org/fiware/mintaka/RetrievalTest.java
+++ b/src/test/java/org/fiware/mintaka/RetrievalTest.java
@@ -100,7 +100,21 @@ public class RetrievalTest extends ComposeTest {
 		MutableHttpRequest getRequest = HttpRequest.GET("/temporal/entities/" + ENTITY_ID);
 		getRequest.getParameters().add("attrs", "nonExisting");
 
-		assertNotFound(getRequest, "If the requested attribute does not exist, a 404 should be returned.");
+		Map<String, String> resultMap = mintakaTestClient.toBlocking().retrieve(getRequest, Map.class);
+		assertEquals(2, resultMap.size(),"Id and type should be returned.");
+		assertEquals(ENTITY_ID.toString(), resultMap.get("id"));
+		assertEquals("store", resultMap.get("type"));
+	}
+
+	@DisplayName("Request an entity without an observedAt attribute.")
+	@Test
+	public void testGetEntityWithoutDefaultTimeAttribute() {
+		MutableHttpRequest getRequest = HttpRequest.GET("/temporal/entities/" + NO_OBSERVED_AT_ENTITY_ID);
+
+		Map<String, String> resultMap = mintakaTestClient.toBlocking().retrieve(getRequest, Map.class);
+		assertEquals(2, resultMap.size(),"Id and type should be returned.");
+		assertEquals(NO_OBSERVED_AT_ENTITY_ID.toString(), resultMap.get("id"));
+		assertEquals("thermometer", resultMap.get("type"));
 	}
 
 	@DisplayName("Retrieve deleted entity should lead to 404.")


### PR DESCRIPTION
Return an "empty" entity in case there are not instances with the requested time property